### PR TITLE
Enable LDAP exceptions and force ssl verify 

### DIFF
--- a/check_389ds_replicats.py
+++ b/check_389ds_replicats.py
@@ -523,10 +523,8 @@ class Check389dsReplicatsApp(object):
     # -------------------------------------------------------------------------
     def init_ldap(self):
 
-        if self.ldap_use_ssl:
-            tls = Tls(validate=self.ldap_ssl_verify)
-        else:
-            tls = Tls(validate=CERT_NONE)
+        # Init Tls object
+        tls = Tls(validate=self.ldap_ssl_verify)
 
         # Init LDAP Server object
         ldap_server = Server(


### PR DESCRIPTION
The LDAP call inside of `check_389ds_replicats.py` suppresses credentials exceptions that lead to the state that the check always return ok even when the ldap connection has failed.
This PR enables the exceptions for the ldap connection. The script already handle these in a way see https://github.com/pixelpark/monitoring-checks/blob/efaac16f6890a4a7bd01b9d580c11fe5375ee448/check_389ds_replicats.py#L671-L676
See documentation https://ldap3.readthedocs.io/en/latest/exceptions.html?highlight=raise_exceptions and https://ldap3.readthedocs.io/en/latest/bind.html?highlight=raise_exceptions#bind-as-a-different-user-while-the-connection-is-open

The SSL verify was missing resulting in the state that even not trusted connections will be used.
This PR sets the `ssl.CERT_REQUIRED` flag via the added Tls object of the ldap3 module when 
See documentation https://ldap3.readthedocs.io/en/latest/ssltls.html#the-tls-object