### PR TITLE
Adding dnf update monitoring checks with DNF hook integration

### DIFF
--- a/check_dnf_update.rb
+++ b/check_dnf_update.rb
@@ -13,25 +13,36 @@ STATES = {
 
 options = {
   warning: 90,
-  critical: 91
+  critical: 91,
+  state_file: '/var/lib/dnf/verify_update_state.log'
 }
 
 OptionParser.new do |opts|
   opts.on('-w WARNING', Integer) { |warning| options[:warning] = warning }
   opts.on('-c CRITICAL', Integer) { |critical| options[:critical] = critical }
+  opts.on('--state-file PATH', String) { |path| options[:state_file] = path }
 end.parse!
+
+last_upgrade = Time.parse('1970-01-01T00:00:00Z')
+unless File.readable?(options[:state_file])
+  puts "#{status[3]} - state file not existing or readable: #{options[:state_file]}"
+  exit 3
+end
+File.open(options[:state_file], 'r') do |file|
+  File.foreach(file) do |line|
+    line = line.split
+    next unless line[1] == '0'
+
+    break if (last_upgrade = Time.parse(line[0]))
+  end
+end
+
+current = Time.now.utc
+threshold_crit = Time.utc(last_upgrade.year, last_upgrade.month, last_upgrade.day, 0, 0, 0) + (options[:critical] * 86_400)
+threshold_warn = Time.utc(last_upgrade.year, last_upgrade.month, last_upgrade.day, 0, 0, 0) + (options[:warning] * 86_400)
 
 # `/bin/dnf list updates` would also show versionlocked packages
 check_update, check_update_status = Open3.capture2e('/bin/dnf --quiet --cacheonly check-update')
-
-kernel, = Open3.capture2e('/bin/dnf repoquery --quiet --cacheonly --qf=\'%{name}-%{version}-%{release}.%{arch} %{installtime}\' --installed kernel') # rubocop:disable Style/FormatStringToken
-kernel = kernel.lines(chomp: true).to_h { |x| x.split(nil, 2) }.max { |a, b| a[1] <=> b[1] }.last
-kernel = Time.parse("#{kernel} UTC")
-
-current = Time.now.utc
-threshold_crit = Time.utc(kernel.year, kernel.month, kernel.day, 10, 0, 0) + (options[:critical] * 86_400)
-threshold_warn = Time.utc(kernel.year, kernel.month, kernel.day, 10, 0, 0) + (options[:warning] * 86_400)
-
 _, needs_restarting = Open3.capture2e('/usr/bin/needs-restarting --reboothint')
 
 status = if (current >= threshold_crit && check_update_status.exitstatus == 100) || !needs_restarting.success?
@@ -43,10 +54,10 @@ status = if (current >= threshold_crit && check_update_status.exitstatus == 100)
          else
            [3, 'UNKOWN']
          end
-output = "#{status[1]} -"
-output += ' System needs restarting!' unless needs_restarting.success?
-output += " Last kernel install: #{kernel}"
-output += ", Updates available:\n#{check_update}" unless check_update_status.success?
+output = status[1]
+output += ' - System needs restarting!' unless needs_restarting.success?
+output += " - Last upgrade: #{last_upgrade}"
+output += "\nUpdates available:\n#{check_update}" unless check_update_status.success?
 
 puts output
 

--- a/check_dnf_update.rb
+++ b/check_dnf_update.rb
@@ -1,0 +1,53 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'optparse'
+require 'open3'
+require 'time'
+
+STATES = {
+  0 => 'OK',
+  1 => 'WARNING',
+  2 => 'CRITICAL',
+  3 => 'UNKOWN'
+}.freeze
+
+options = {
+  warning: 90,
+  critical: 91
+}
+
+OptionParser.new do |opts|
+  opts.on('-w WARNING', Integer) { |warning| options[:warning] = warning }
+  opts.on('-c CRITICAL', Integer) { |critical| options[:critical] = critical }
+end.parse!
+
+# `/bin/dnf list updates` would also show versionlocked packages
+check_update, check_update_status = Open3.capture2e('/bin/dnf --quiet --cacheonly check-update')
+
+kernel, = Open3.capture2e('/bin/dnf repoquery --quiet --cacheonly --qf=\'%{name}-%{version}-%{release}.%{arch} %{installtime}\' --installed kernel') # rubocop:disable Style/FormatStringToken
+kernel = kernel.lines(chomp: true).to_h { |x| x.split(nil, 2) }.max { |a, b| a[1] <=> b[1] }.last
+kernel = Time.parse("#{kernel} UTC")
+
+current = Time.now.utc
+threshold_crit = Time.utc(kernel.year, kernel.month, kernel.day, 10, 0, 0) + (options[:critical] * 86_400)
+threshold_warn = Time.utc(kernel.year, kernel.month, kernel.day, 10, 0, 0) + (options[:warning] * 86_400)
+
+_, needs_restarting = Open3.capture2e('/usr/bin/needs-restarting --reboothint')
+
+status = if (current >= threshold_crit && check_update_status.exitstatus == 100) || !needs_restarting.success?
+           [2, 'CRITICAL']
+         elsif current >= threshold_warn && check_update_status.exitstatus == 100
+           [1, 'WARNING']
+         elsif check_update_status.success?
+           [0, 'OK']
+         else
+           [3, 'UNKOWN']
+         end
+output = "#{status[1]} -"
+output += ' System needs restarting!' unless needs_restarting.success?
+output += " Last kernel install: #{kernel}"
+output += ", Updates available:\n#{check_update}" unless check_update_status.success?
+
+puts output
+
+exit status[0]

--- a/verify_update_state.rb
+++ b/verify_update_state.rb
@@ -1,0 +1,37 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+# Usage with DNF:
+#   dnf install python3-dnf-plugin-post-transaction-actions
+#   echo '*:any:/path/to/check_last_update_state.rb' > /etc/dnf/plugins/post-transaction-actions.d/verify_update_state.action
+
+require 'open3'
+require 'time'
+require 'tempfile'
+
+_, check_update_status = Open3.capture2e('/bin/dnf --quiet --cacheonly check-update')
+history, = Open3.capture2e({ 'LC_ALL' => 'C', 'LANG' => 'C' }, '/bin/dnf --quiet --cacheonly history info last')
+id = case history
+     when /^Transaction ID\s+:\s+(?<status_code>\d+)$/
+       Regexp.last_match(:status_code)
+     else
+       '-'
+     end
+
+Tempfile.open do |tempfile|
+  tempfile.puts("#{Time.now.utc.strftime('%FT%TZ')} #{check_update_status.exitstatus} #{id}")
+  File.open("/var/lib/dnf/#{File.basename(__FILE__, File.extname(__FILE__))}.log", 'r+', 644) do |file|
+    File.foreach(file) do |line|
+      tempfile.puts(line)
+    end
+    file.rewind
+    tempfile.rewind
+    File.foreach(tempfile).with_index do |line, i|
+      break if i >= 200
+
+      file.puts(line)
+    end
+    file.truncate(file.pos)
+  end
+end
+
+exit 0


### PR DESCRIPTION
Uses [DNF post-transaction-actions Plugin](https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html) hook to document `check-update` changes after each dnf transaction.
The last transaction which no pending update is used as last system patch date for `check_dnf_update.rb`.